### PR TITLE
chore(typing): exports other types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-interface SimpleEncryptor {
+export interface SimpleEncryptor {
     /**
      *  Encrypts an arbitrary object using the derived cryptoKey and retursn the result as text.
      *  The object is first serialized to JSON (via JSON.stringify) and the result is encrypted.
@@ -18,7 +18,7 @@ interface SimpleEncryptor {
     hmac(text: string, encoding?: string): string
 }
 
-interface SimpleEncryptorOptions {
+export interface SimpleEncryptorOptions {
     key: string;
     hmac: boolean;
     debug: boolean;


### PR DESCRIPTION
Heya!

Currently we need to create our own type to be able to use the type `SimpleEncryptor` in our application.

e.g:
```ts
import Encryptor from 'simple-encryptor'
type SimpleEncryptor = ReturnType<typeof Encryptor>

class Foo {
  public encryptor: SimpleEncryptor
}
```

With this change, it let us also import the type directly in the import statement.

e.g:
```ts
import Encryptor, { SimpleEncryptor } from 'simple-encryptor'

class Foo {
  public encryptor: SimpleEncryptor
}
```