### PR TITLE
[Types] Fix error TS2309 in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,4 +27,4 @@ export interface SimpleEncryptorOptions {
 
 declare function encryptorCreator(opts: SimpleEncryptorOptions): SimpleEncryptor;
 declare function encryptorCreator(key: string): SimpleEncryptor;
-export = encryptorCreator;
+export default encryptorCreator;


### PR DESCRIPTION
Using simple-encryptor with typescript, I can't build the code due to error `TS2309: An export assignment cannot be used in a module with other exported elements` due to `export = encryptorCreator` in `index.d.ts`

Tested on typescript 2.9.2