### PR TITLE
Fixes algorithm name (closes #13)

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = function(opts) {
     var iv = crypto.randomBytes(16);
 
     // Make sure to use the 'iv' variant when creating the cipher object:
-    var cipher = crypto.createCipheriv('aes256', cryptoKey, iv);
+    var cipher = crypto.createCipheriv('aes-256-cbc', cryptoKey, iv);
 
     // Generate the encrypted json:
     var encryptedJson = cipher.update(json, 'utf8', 'base64') + cipher.final('base64');
@@ -102,7 +102,7 @@ module.exports = function(opts) {
       var encryptedJson = cipherText.substring(32);
 
       // Make sure to use the 'iv' variant when creating the decipher object:
-      var decipher = crypto.createDecipheriv('aes256', cryptoKey, iv);
+      var decipher = crypto.createDecipheriv('aes-256-cbc', cryptoKey, iv);
       // Decrypt the JSON:
       var json = decipher.update(encryptedJson, 'base64', 'utf8') + decipher.final('utf8');
 


### PR DESCRIPTION
Changes algorithm name from `aes256` to `aes-256-cbc` both in encrypt and decrypt.
Solves issue #13. After this edit, the tutorial works both with node and electron on Windows 10I didn't test it formally.